### PR TITLE
加入对崩坏3和识宝小助手的支持

### DIFF
--- a/src/script_chainer/config/script_config.py
+++ b/src/script_chainer/config/script_config.py
@@ -29,7 +29,7 @@ class GameProcessName(Enum):
     STAR_RAIL_CN = ConfigItem(label='崩坏：星穹铁道', value='StarRail.exe')
     ZZZ_CN = ConfigItem(label='绝区零', value='ZenlessZoneZero.exe')
     HONKAI_IMPACT_CN = ConfigItem(label='崩坏3', value='BH3.exe')
-    LD_Simulator = ConfigItem(label='雷电模拟器', value='dnplayer.exe')
+    MUMU = ConfigItem(label='MUMU模拟器', value='MuMuNxDevice.exe')
 
 
 


### PR DESCRIPTION
<img width="2545" height="1599" alt="屏幕截图 2025-11-23 113655" src="https://github.com/user-attachments/assets/27c15d0c-1d0b-430a-85ca-329372f515d0" />
补了一下崩坏3和识宝小助手（仅桌面端）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加对“识宝小助手”应用的支持
  * 添加对“StarRailAssistant”应用的支持
  * 添加对“MaaGF2Exilium”应用的支持
  * 添加对“崩坏3”游戏的支持
  * 添加对“MUMU模拟器”支持

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->