### PR TITLE
fix: 修复脚本路径保存时使用UI省略文本导致长路径保存失败的问题 

### DIFF
--- a/src/script_chainer/gui/page/script_setting_interface.py
+++ b/src/script_chainer/gui/page/script_setting_interface.py
@@ -221,7 +221,7 @@ class ScriptEditDialog(MessageBoxBase):
 
     def get_config_value(self) -> ScriptConfig:
         config = self.config.copy()
-        config.script_path = self.script_path_opt.contentLabel.text()
+        config.script_path = self.config.script_path
         config.script_process_name = self._get_editable_combo_value(self.script_process_name_opt)
         config.game_process_name = self._get_editable_combo_value(self.game_process_name_opt)
         config.run_timeout_seconds = int(self.run_timeout_seconds_opt.getValue())


### PR DESCRIPTION
Fixes #41

## 问题说明

在脚本编辑对话框中，保存配置时脚本路径取自界面控件的显示文本：

```python
config.script_path = self.script_path_opt.contentLabel.text()
```

但 `SettingCardBase.setContent()` 会对过长文本做省略显示（elide），导致 `contentLabel.text()` 返回的是被截断后的显示文本（如 `C:\...\ZenlessZoneZero-OneDragon-1.5.0\ZenlessZoneZero-...`），而非完整路径。

这会导致：
- `os.path.exists()` 校验失败
- 弹出"脚本路径不存在 ..."的错误提示
- 长路径脚本无法正常保存

## 修复方案

将 `get_config_value()` 中的脚本路径来源从 UI 显示文本改为 `self.config.script_path`，因为完整路径在文件选择时已保存到 config 对象中：

```python
# Before (bug)
config.script_path = self.script_path_opt.contentLabel.text()

# After (fix)
config.script_path = self.config.script_path
```

## 根因分析

`contentLabel.text()` 返回的是用于展示的文本，不是原始数据。而完整脚本路径在 `on_script_path_chosen()` 中已保存到 `self.config.script_path`，属于 UI 展示值与实际数据值混用的问题。

### 测试
- 本地已测试，修改前脚本启动报错，修改后脚本正常启动运行。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug修复

* 修复了脚本设置对话框中脚本路径配置的读取机制，优化了配置值的管理方式，确保所保存的脚本路径设置能够正确加载和恢复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->