### PR TITLE
feat: 支持源码模式运行脚本链

### DIFF
--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
+from one_dragon.utils.os_utils import get_work_dir, get_path_under_work_dir
 
+
+def get_launcher_path() -> str:
+    """获取 launcher 路径。"""
+    repo_root = get_work_dir()
+    return get_path_under_work_dir(repo_root, "src", "script_chainer", "win_exe", "launcher.py")
 
 def build_runner_command(chain_name: str, script_index: int | None = None) -> tuple[list[str], str | None]:
     """构造 runner 启动命令。
@@ -24,14 +29,8 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
         command = [sys.executable, *common_args]
         return command, os.path.dirname(sys.executable) or None
     else: # 源码模式
-        file_path = Path(__file__).resolve()
-        if len(file_path.parents) < 4:
-            raise RuntimeError(f"无法确定仓库根目录: {file_path}")
-
-        # 根据该文件路径OneDragon-ScriptChainer\\src\\script_chainer\\utils\\runner_utils.py
-        # 上跳三级得到仓库根目录 OneDragon-ScriptChainer
-        repo_root = str(file_path.parents[3])
-        launcher_path = str(Path(repo_root) / "src" / "script_chainer" / "win_exe" / "launcher.py")
+        repo_root = get_work_dir()
+        launcher_path = get_launcher_path()
         command = [
             sys.executable,
             launcher_path,

--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 import os
 import sys
-from one_dragon.utils.os_utils import get_work_dir, get_path_under_work_dir
+from one_dragon.utils.os_utils import get_path_under_work_dir
 
-
-def get_launcher_path() -> str:
-    """获取 launcher 路径。"""
-    return get_path_under_work_dir("src", "script_chainer", "win_exe", "launcher.py")
 
 def build_runner_command(chain_name: str, script_index: int | None = None) -> tuple[list[str], str | None]:
     """构造 runner 启动命令。
@@ -28,11 +24,11 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
         command = [sys.executable, *common_args]
         return command, os.path.dirname(sys.executable) or None
     else: # 源码模式
-        repo_root = get_work_dir()
-        launcher_path = get_launcher_path()
+        launcher_work_dir = get_path_under_work_dir("src")
         command = [
             sys.executable,
-            launcher_path,
+            "-m",
+            "script_chainer.win_exe.launcher",
             *common_args,
         ]
-        return command, repo_root
+        return command, launcher_work_dir

--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -15,28 +15,26 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
     Returns:
         启动命令及其工作目录。
     """
+    common_args = ["--onedragon", "--chain", chain_name]
+    if script_index is not None:
+        common_args.extend(["--debug-index", str(script_index)])
+
+    # 可执行文件模式
     if getattr(sys, 'frozen', False):
-        command = [
-            sys.executable,
-            '--onedragon',
-            '--chain',
-            chain_name,
-        ]
-        if script_index is not None:
-            command.extend(['--debug-index', str(script_index)])
+        command = [sys.executable, *common_args]
         return command, os.path.dirname(sys.executable) or None
     else: # 源码模式
+        file_path = Path(__file__).resolve()
+        if len(file_path.parents) < 4:
+            raise RuntimeError(f"无法确定仓库根目录: {file_path}")
+
         # 根据该文件路径OneDragon-ScriptChainer\\src\\script_chainer\\utils\\runner_utils.py
         # 上跳三级得到仓库根目录 OneDragon-ScriptChainer
-        repo_root = str(Path(__file__).resolve().parents[3])
-        launcher_path = os.path.join(repo_root, "src", "script_chainer", "win_exe", "launcher.py")
+        repo_root = str(file_path.parents[3])
+        launcher_path = str(Path(repo_root) / "src" / "script_chainer" / "win_exe" / "launcher.py")
         command = [
             sys.executable,
             launcher_path,
-            "--onedragon",
-            "--chain",
-            chain_name,
+            *common_args,
         ]
-        if script_index is not None:
-            command.extend(["--debug-index", str(script_index)])
         return command, repo_root

--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 
 def build_runner_command(chain_name: str, script_index: int | None = None) -> tuple[list[str], str | None]:
@@ -13,9 +14,6 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
 
     Returns:
         启动命令及其工作目录。
-
-    Raises:
-        RuntimeError: 源码模式下不支持运行脚本链。
     """
     if getattr(sys, 'frozen', False):
         command = [
@@ -27,5 +25,18 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
         if script_index is not None:
             command.extend(['--debug-index', str(script_index)])
         return command, os.path.dirname(sys.executable) or None
-
-    raise RuntimeError('源码模式下不支持运行脚本链，请使用打包后的程序。')
+    else: # 源码模式
+        command = [
+            sys.executable,
+            "-m",
+            "src.script_chainer.win_exe.launcher",
+            "--onedragon",
+            "--chain",
+            chain_name,
+        ]
+        if script_index is not None:
+            command.extend(["--debug-index", str(script_index)])
+        # 根据该文件路径OneDragon-ScriptChainer\\src\\script_chainer\\utils\\runner_utils.py
+        # 上跳三级得到仓库根目录 OneDragon-ScriptChainer
+        repo_root = str(Path(__file__).resolve().parents[3])
+        return command, repo_root

--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -26,17 +26,17 @@ def build_runner_command(chain_name: str, script_index: int | None = None) -> tu
             command.extend(['--debug-index', str(script_index)])
         return command, os.path.dirname(sys.executable) or None
     else: # 源码模式
+        # 根据该文件路径OneDragon-ScriptChainer\\src\\script_chainer\\utils\\runner_utils.py
+        # 上跳三级得到仓库根目录 OneDragon-ScriptChainer
+        repo_root = str(Path(__file__).resolve().parents[3])
+        launcher_path = os.path.join(repo_root, "src", "script_chainer", "win_exe", "launcher.py")
         command = [
             sys.executable,
-            "-m",
-            "src.script_chainer.win_exe.launcher",
+            launcher_path,
             "--onedragon",
             "--chain",
             chain_name,
         ]
         if script_index is not None:
             command.extend(["--debug-index", str(script_index)])
-        # 根据该文件路径OneDragon-ScriptChainer\\src\\script_chainer\\utils\\runner_utils.py
-        # 上跳三级得到仓库根目录 OneDragon-ScriptChainer
-        repo_root = str(Path(__file__).resolve().parents[3])
         return command, repo_root

--- a/src/script_chainer/utils/runner_utils.py
+++ b/src/script_chainer/utils/runner_utils.py
@@ -7,8 +7,7 @@ from one_dragon.utils.os_utils import get_work_dir, get_path_under_work_dir
 
 def get_launcher_path() -> str:
     """获取 launcher 路径。"""
-    repo_root = get_work_dir()
-    return get_path_under_work_dir(repo_root, "src", "script_chainer", "win_exe", "launcher.py")
+    return get_path_under_work_dir("src", "script_chainer", "win_exe", "launcher.py")
 
 def build_runner_command(chain_name: str, script_index: int | None = None) -> tuple[list[str], str | None]:
     """构造 runner 启动命令。


### PR DESCRIPTION
## 变更
 `build_runner_command` 新增源码模式支持：
非 frozen 环境下, 选择src作为子进程的workdir，并使用模块方式启动
  `python -m script_chainer.win_exe.launcher.py --onedragon --chain ...`

## 价值
- 本地开发可直接在源码模式运行脚本链，无需先打包 exe
- 显著简化联调/回归测试流程，缩短验证时间

## 测试
cd OneDragon-ScriptChainer/src
uv run python -m script_chainer.win_exe.launcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复源码模式下启动异常：现在会自动生成可直接运行的启动命令与工作目录，无需先编译或打包。
  * 优化源码模式启动方式：改为使用统一的启动器入口，并确保链式任务参数（含调试索引）按公共参数规则追加传递。
  * 改进工作目录识别：冻结/打包与源码模式下的工作目录与执行方式更一致，提升资源加载稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->