### PR TITLE
fix: 修复配置页面返回时悬空 Qt 对象访问

### DIFF
--- a/src/one_dragon_qt/widgets/setting_card/expand_setting_card_group.py
+++ b/src/one_dragon_qt/widgets/setting_card/expand_setting_card_group.py
@@ -5,6 +5,7 @@ from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QWidget
 from qfluentwidgets import ExpandSettingCard, FluentIcon
 from qfluentwidgets.components.settings.expand_setting_card import GroupSeparator
+from shiboken6 import isValid
 
 from one_dragon.utils.i18_utils import gt
 
@@ -72,8 +73,12 @@ class ExpandSettingCardGroup(ExpandSettingCard):
 
     def _update_separators(self) -> None:
         """根据卡片可见性更新分隔线：仅当当前卡片可见且前面存在可见卡片时才显示分隔线"""
+        if not isValid(self):
+            return
         has_visible_before = False
         for card, sep in self._card_sep_pairs:
+            if not isValid(card):
+                continue
             if sep is not None:
                 sep.setVisible(card.isVisible() and has_visible_before)
             if card.isVisible():


### PR DESCRIPTION
fix https://github.com/OneDragon-Anything/OneDragon-ScriptChainer/issues/65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改善设置卡片组对已失效或已销毁控件的处理，避免更新分隔线时发生异常。
  * 优化分隔线显示状态更新，提升设置界面的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->